### PR TITLE
added_valid_error_code

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   checksumType  = 'sha256'
 
   silentArgs   = '/U'
-  validExitCodes= @(0)
+  validExitCodes= @(0, 1023)
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
1023 is a error code when Visual C++ redist already exists. See https://docs.microsoft.com/en-us/troubleshoot/windows/win32/s1023-error-when-you-install-directx-sdk